### PR TITLE
Remove DroidGap dep for Cordova 4.0 compatibility

### DIFF
--- a/src/android/FileViewerPlugin.java
+++ b/src/android/FileViewerPlugin.java
@@ -5,7 +5,6 @@ import java.util.Map;
 
 import java.io.File;
 
-import org.apache.cordova.DroidGap;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;


### PR DESCRIPTION
Easy fix. It simply wasn't used.